### PR TITLE
Support different message_id domains for different AWS SES regions

### DIFF
--- a/lib/mail/ses.rb
+++ b/lib/mail/ses.rb
@@ -23,7 +23,10 @@ module Mail
       @error_handler = options.delete(:error_handler)
       raise ArgumentError.new(':error_handler must be a Proc') if @error_handler && !@error_handler.is_a?(Proc)
 
-      @settings = { return_response: options.delete(:return_response), message_id_domain: options.delete(:message_id_domain) }
+      @settings = {
+        return_response: options.delete(:return_response),
+        message_id_domain: options.delete(:message_id_domain)
+      }
 
       options[:credentials] = Aws::InstanceProfileCredentials.new if options.delete(:use_iam_profile)
       @client = Aws::SESV2::Client.new(options)
@@ -43,8 +46,7 @@ module Mail
 
       begin
         response = client.send_email(send_options)
-        message_id_domain = settings[:message_id_domain] || "email.amazonses.com"
-        message.message_id = "#{response.to_h[:message_id]}@#{message_id_domain}"
+        message.message_id = "#{response.to_h[:message_id]}@#{settings[:message_id_domain] || 'email.amazonses.com'}"
         settings[:return_response] ? response : self
       rescue StandardError => e
         handle_error(e, send_options)

--- a/lib/mail/ses.rb
+++ b/lib/mail/ses.rb
@@ -23,7 +23,7 @@ module Mail
       @error_handler = options.delete(:error_handler)
       raise ArgumentError.new(':error_handler must be a Proc') if @error_handler && !@error_handler.is_a?(Proc)
 
-      @settings = { return_response: options.delete(:return_response) }
+      @settings = { return_response: options.delete(:return_response), message_id_domain: options.delete(:message_id_domain) }
 
       options[:credentials] = Aws::InstanceProfileCredentials.new if options.delete(:use_iam_profile)
       @client = Aws::SESV2::Client.new(options)
@@ -43,7 +43,8 @@ module Mail
 
       begin
         response = client.send_email(send_options)
-        message.message_id = "#{response.to_h[:message_id]}@email.amazonses.com"
+        message_id_domain = settings[:message_id_domain] || "email.amazonses.com"
+        message.message_id = "#{response.to_h[:message_id]}@#{message_id_domain}"
         settings[:return_response] ? response : self
       rescue StandardError => e
         handle_error(e, send_options)

--- a/spec/mail_ses_spec.rb
+++ b/spec/mail_ses_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Mail::SES do
   describe '#settings' do
     it do
       expect(ses).to respond_to(:settings, :settings=)
-      expect(ses.settings).to eq(return_response: nil)
+      expect(ses.settings).to eq(return_response: nil, message_id_domain: nil)
     end
   end
 
@@ -99,9 +99,19 @@ RSpec.describe Mail::SES do
       end
     end
 
-    it 'sets mail.message_id' do
-      ses.deliver!(mail)
-      expect(mail.message_id).to eq('OutboundMessageId@email.amazonses.com')
+    context "without message_id_domain config" do
+      it 'sets the default domain as mail.message_id' do
+        ses.deliver!(mail)
+        expect(mail.message_id).to eq('OutboundMessageId@email.amazonses.com')
+      end
+    end
+
+    context "with message_id_domain config" do
+      let(:ses_options) { { stub_responses: true, message_id_domain: 'eu-west-1.amazonses.com' } }
+      it 'sets as mail.message_id with the configured domain' do
+        ses.deliver!(mail)
+        expect(mail.message_id).to eq('OutboundMessageId@eu-west-1.amazonses.com')
+      end
     end
 
     it 'returns the AWS response' do


### PR DESCRIPTION
Emails sent from, for example, the eu-west-1 region will have a different message_id, ending in `eu-west-1.amazonses.com` instead of `email.amazonses.com`.